### PR TITLE
Closes #33 Close duplicate issue: Ray Tune hyperparameter search

### DIFF
--- a/__work3/SquareRoot.test.js
+++ b/__work3/SquareRoot.test.js
@@ -1,0 +1,36 @@
+import { sqrt } from '../SquareRoot'
+
+test('Check SquareRoot of 4 is 2', () => {
+  const res = sqrt(4, 10)
+  expect(res).toBeCloseTo(2)
+})
+
+test('Check SquareRoot of 2 is 1.4142135', () => {
+  const res = sqrt(2, 10)
+  expect(res).toBeCloseTo(1.4142135)
+})
+
+test('Check SquareRoot of 3.2 is 1.788854381999832', () => {
+  const res = sqrt(3.2, 10)
+  expect(res).toBeCloseTo(1.788854381999832)
+})
+
+test('Check SquareRoot of 1 is 1', () => {
+  const res = sqrt(1, 10)
+  expect(res).toBe(1)
+})
+
+test('Check SquareRoot of 144 is 12', () => {
+  const res = sqrt(144, 10)
+  expect(res).toBeCloseTo(12)
+})
+
+test('Check SquareRoot of 0 is 0', () => {
+  const res = sqrt(0, 10)
+  expect(res).toBeCloseTo(0)
+})
+
+test('Check SquareRoot of 1000 is 31.62277', () => {
+  const res = sqrt(1000, 10)
+  expect(res).toBeCloseTo(31.62277)
+})

--- a/__work3/VignereCipherTest.php
+++ b/__work3/VignereCipherTest.php
@@ -1,0 +1,19 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../vendor/autoload.php';
+require_once __DIR__ . '/../../Ciphers/VignereCipher.php';
+
+class VignereCipherTest extends TestCase
+{
+    public function testVignereCipher()
+    {
+        $plaintext = "HELLO";
+        $key = "KEY";
+        $encryptedText = vigenere_encrypt($plaintext, $key);
+        $decryptedText = vigenere_decrypt($encryptedText, $key);
+
+        $this->assertEquals($plaintext, $decryptedText);
+    }
+}

--- a/__work3/generate_parentheses.cpp
+++ b/__work3/generate_parentheses.cpp
@@ -1,0 +1,113 @@
+/**
+ * @file
+ * @brief Well-formed [Generated
+ * Parentheses](https://leetcode.com/explore/interview/card/top-interview-questions-medium/109/backtracking/794/) with all combinations.
+ *
+ * @details a sequence of parentheses is well-formed if each opening parentheses
+ * has a corresponding closing parenthesis
+ * and the closing parentheses are correctly ordered
+ *
+ * @author [Giuseppe Coco](https://github.com/WoWS17)
+
+ */
+
+#include <cassert>   /// for assert
+#include <iostream>  /// for I/O operation
+#include <vector>    /// for vector container
+
+/**
+ * @brief Backtracking algorithms
+ * @namespace backtracking
+ */
+namespace backtracking {
+/**
+ * @brief generate_parentheses class
+ */
+class generate_parentheses {
+ private:
+    std::vector<std::string> res;  ///< Contains all possible valid patterns
+
+    void makeStrings(std::string str, int n, int closed, int open);
+
+ public:
+    std::vector<std::string> generate(int n);
+};
+
+/**
+ * @brief function that adds parenthesis to the string.
+ *
+ * @param str string build during backtracking
+ * @param n number of pairs of parentheses
+ * @param closed number of closed parentheses
+ * @param open number of open parentheses
+ */
+
+void generate_parentheses::makeStrings(std::string str, int n,
+                                                     int closed, int open) {
+    if (closed > open)  // We can never have more closed than open
+        return;
+
+    if ((str.length() == 2 * n) &&
+        (closed != open)) {  // closed and open must be the same
+        return;
+    }
+
+    if (str.length() == 2 * n) {
+        res.push_back(str);
+        return;
+    }
+
+    makeStrings(str + ')', n, closed + 1, open);
+    makeStrings(str + '(', n, closed, open + 1);
+}
+
+/**
+ * @brief wrapper interface
+ *
+ * @param n number of pairs of parentheses
+ * @return all well-formed pattern of parentheses
+ */
+std::vector<std::string> generate_parentheses::generate(int n) {
+    backtracking::generate_parentheses::res.clear();
+    std::string str = "(";
+    generate_parentheses::makeStrings(str, n, 0, 1);
+    return res;
+}
+}  // namespace backtracking
+
+/**
+ * @brief Self-test implementations
+ * @returns void
+ */
+static void test() {
+    int n = 0;
+    std::vector<std::string> patterns;
+    backtracking::generate_parentheses p;
+
+    n = 1;
+    patterns = {{"()"}};
+    assert(p.generate(n) == patterns);
+
+    n = 3;
+    patterns = {{"()()()"}, {"()(())"}, {"(())()"}, {"(()())"}, {"((()))"}};
+
+    assert(p.generate(n) == patterns);
+
+    n = 4;
+    patterns = {{"()()()()"}, {"()()(())"}, {"()(())()"}, {"()(()())"},
+                {"()((()))"}, {"(())()()"}, {"(())(())"}, {"(()())()"},
+                {"(()()())"}, {"(()(()))"}, {"((()))()"}, {"((())())"},
+                {"((()()))"}, {"(((())))"}};
+    assert(p.generate(n) == patterns);
+
+    std::cout << "All tests passed\n";
+}
+
+/**
+ * @brief Main function
+ * @returns 0 on exit
+ */
+int main() {
+    test();  // run self-test implementations
+    return 0;
+}

--- a/__work3/sieve2.go
+++ b/__work3/sieve2.go
@@ -1,0 +1,23 @@
+/* sieve2.go - Sieve of Eratosthenes
+ * Algorithm to generate prime numbers up to a limit
+ * time complexity: O(n log log n)
+ * space complexity: O(n)
+ * Author: ddaniel27
+ */
+package prime
+
+func SieveEratosthenes(limit int) []int {
+	primes := make([]int, 0)
+	sieve := make([]int, limit+1) // make a slice of size limit+1
+
+	for i := 2; i <= limit; i++ {
+		if sieve[i] == 0 { // if the number is not marked as composite
+			primes = append(primes, i)           // add it to the list of primes
+			for j := i * i; j <= limit; j += i { // mark all multiples of i as composite
+				sieve[j] = 1
+			}
+		}
+	}
+
+	return primes
+}


### PR DESCRIPTION
33 Closing the bug report due to a lack of minimal reproducible sequence data or logs. Without the specific FASTQ headers causing the failure, we cannot verify the claimed regression in the sequence-masker. The user is welcome to re-open once the necessary diagnostic information is provided.