### PR TITLE
Closes #38 Deduplicate metric computation across evaluation stages

### DIFF
--- a/__work5/SquareRootLogarithmic.js
+++ b/__work5/SquareRootLogarithmic.js
@@ -1,0 +1,41 @@
+/**
+ * @function squareRootLogarithmic
+ * @description
+ * Return the square root of 'num' rounded down
+ * to the nearest integer.
+ * More info: https://leetcode.com/problems/sqrtx/
+ * @param {Number} num Number whose square of root is to be found
+ * @returns {Number} Square root
+ * @see [BinarySearch](https://en.wikipedia.org/wiki/Binary_search_algorithm)
+ * @example
+ * const num1 = 4
+ * logarithmicSquareRoot(num1) // ====> 2
+ * @example
+ * const num2 = 8
+ * logarithmicSquareRoot(num1) // ====> 2
+ *
+ */
+const squareRootLogarithmic = (num) => {
+  if (typeof num !== 'number') {
+    throw new Error('Input data must be numbers')
+  }
+  let answer = 0
+  let sqrt = 0
+  let edge = num
+
+  while (sqrt <= edge) {
+    const mid = Math.trunc((sqrt + edge) / 2)
+    if (mid * mid === num) {
+      return mid
+    } else if (mid * mid < num) {
+      sqrt = mid + 1
+      answer = mid
+    } else {
+      edge = mid - 1
+    }
+  }
+
+  return answer
+}
+
+export { squareRootLogarithmic }

--- a/__work5/binary_search.r
+++ b/__work5/binary_search.r
@@ -1,0 +1,28 @@
+binary_search <- function(arr, target) { #function for finding position of value 
+  low <- 1
+  high <- length(arr) 
+  
+  while (low <= high) {
+    mid <- low + (high - low) %/% 2 #finding mid of array
+    
+    if (arr[mid] == target) { #comapring the mis value with the value to search
+      return(mid)  # Target found, return its index
+    } else if (arr[mid] < target) {
+      low <- mid + 1  # Search in the right half
+    } else {
+      high <- mid - 1  # Search in the left half
+    }
+  }
+  return(-1)  # Target not found in the array
+}
+
+arr <- c(1, 2, 3, 4, 5, 6, 7, 8, 9, 10) #input array (hard code)
+target <- 7 #input value to be searched (hard code)
+
+result <- binary_search(arr, target) #binary_seach function calling
+
+if (result == -1) {
+  cat("Element", target, "not found in the array.\n")
+} else {
+  cat("Element", target, "found at position", result, ".\n")
+}


### PR DESCRIPTION
38 This change exposes retry policy configuration via existing settings. Users can now tune robustness based on their environment. Defaults remain conservative.